### PR TITLE
Revert "core: copy installed ramdisk and bootloader to BOOT/"

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1693,12 +1693,6 @@ endif
 ifdef INSTALLED_KERNEL_TARGET
 	$(hide) $(ACP) $(INSTALLED_KERNEL_TARGET) $(zip_root)/BOOT/kernel
 endif
-ifdef INSTALLED_RAMDISK_TARGET
-	$(hide) $(ACP) $(INSTALLED_RAMDISK_TARGET) $(zip_root)/BOOT/ramdisk.img
-endif
-ifdef INSTALLED_BOOTLOADER_MODULE
-	$(hide) $(ACP) $(INSTALLED_BOOTLOADER_MODULE) $(zip_root)/BOOT/bootloader
-endif
 ifdef INSTALLED_2NDBOOTLOADER_TARGET
 	$(hide) $(ACP) \
 		$(INSTALLED_2NDBOOTLOADER_TARGET) $(zip_root)/BOOT/second


### PR DESCRIPTION
This reverts commit 3f39d419f474bfbc2286b23e092709fcd44f076b.

Since this is causing problems it should be reverted. I only wrote it to get Encore booting. It will probably never become official and need this commit. We can just keep cherry-picking it for personal builds. 
If other devices need it because of similarly weird boot methods it can be kept but Fugu is a lot more important than Encore.

Change-Id: I123d33c1559fb8b271a849e978c6d5666628884e